### PR TITLE
Add docs README with design subtask

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# BantuPay Documentation
+
+## Target Audience
+
+- Developers
+- Designers
+- Product Managers
+- Ensure the design system follows an 8pt grid, uses brand tokens, supports theme switching with Ant Design Mobile, and is documented in Storybook
+
+## Subtasks
+
+- [ ] Scaffold React Native app
+


### PR DESCRIPTION
## Summary
- add a docs folder with README
- include design subtask with reference to brand tokens, theme switching, 8pt grid, Ant Design Mobile and Storybook

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68565a782be8832fa256ba60885fa610