### PR TITLE
Add web IDE instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ This repository contains a minimal React Native scaffold for a mobile Super-App 
 MoMo API credentials need to be configured inside `app/momo-api/index.js`.
 
 This scaffold is intentionally lightweight and can be expanded with additional MiniApps and features.
+
+## Using a Web-Based Server
+
+If `npm` is unavailable on your local machine, you can run the project in a
+web-based development environment such as Gitpod or Replit. These services come
+with Node and npm preinstalled.
+
+1. Fork this repository and open it in your chosen web IDE.
+2. Install dependencies with `npm install` inside the IDE terminal.
+3. Start the Metro server using `npm start`.
+4. Launch the app using the emulator options provided by the service.
+
+Running the project this way lets you avoid local npm issues while still
+testing the React Native application.


### PR DESCRIPTION
## Summary
- document how to run in a web-based environment when local `npm` fails

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c4e8a1308832fa9cfa781569a3cd9